### PR TITLE
Update circle_session_page.dart

### DIFF
--- a/lib/app/circle/circle_session_page.dart
+++ b/lib/app/circle/circle_session_page.dart
@@ -147,8 +147,8 @@ class CircleSessionPageState extends ConsumerState<CircleSessionPage>
         // circle is complete or cancelled, so will have to start a new one
         // Make sure there isn't a new one already started as well,
         // should only be 1 that is waiting with a previous circle referencing this one
-        SnapCircle? pending = await repo.circleFromPreviousIdAndNotState(
-            circle.id, [SessionState.cancelled, SessionState.complete]);
+        SnapCircle? pending = await repo.circleFromPreviousIdAndState(circle.id,
+            [SessionState.waiting, SessionState.starting, SessionState.live]);
         if (pending == null) {
           // this is a create new circle moment
           circle = await repo.createSnapCircle(


### PR DESCRIPTION
This fixes the lookup for an existing circle using the previous id (the value from a link or just a refresh)