### PR TITLE
Issue #266 Sign out fix

### DIFF
--- a/lib/app/profile/user_profile_page.dart
+++ b/lib/app/profile/user_profile_page.dart
@@ -485,7 +485,6 @@ class UserProfilePageState extends ConsumerState<UserProfilePage> {
       setState(() => _busy = true);
       await ref.read(authServiceProvider).signOut();
       if (!mounted) return;
-      Navigator.of(context).pop();
     }
   }
 


### PR DESCRIPTION
Fix for #266 
* Removed `Navigator.of(context).pop()` from the sign out dialog flow. Redirecting to the login page is already handled by the auth state. This was causing the stack to try and pop the login screen, causing the crash.