### PR TITLE
Enable web CI release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,27 @@ on:
       - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
 
 jobs:
+  build_web:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.0.x'
+          cache: true
+      - run: make build-web
+      - run: zip -r web build/web
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: web.zip
+          body: Internal release
+      - uses: FirebaseExtended/action-hosting-deploy@v0
+        with:
+          repoToken: '${{ secrets.GITHUB_TOKEN }}'
+          firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_TOTEM_26659 }}'
+          channelId: live
   build_ios:
    runs-on: macos-11
    steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,61 +18,61 @@ jobs:
           cache: true
       - run: make build-web
       - run: zip -r web build/web
-      # - name: Release
-      #   uses: softprops/action-gh-release@v1
-      #   with:
-      #     files: web.zip
-      #     body: Internal release
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: web.zip
+          body: Internal release
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: '${{ secrets.GITHUB_TOKEN }}'
           firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_TOTEM_26659 }}'
           channelId: live
-  # build_ios:
-  #  runs-on: macos-11
-  #  steps:
-  #   - uses: actions/checkout@v2
-  #   - name: Install Flutter
-  #     uses: subosito/flutter-action@v2
-  #     with:
-  #       flutter-version: '3.0.x'
-  #       cache: true
-  #   - uses: webfactory/ssh-agent@v0.5.4
-  #     with:
-  #       ssh-private-key: ${{ secrets.MATCH_REPO_PRIVATE_KEY }}
-  #   - run: fastlane ios build
-  #     env:
-  #       MATCH_PASSWORD: ${{ secrets.FASTLANE_MATCH_PASSWORD }}
-  #   - name: Release
-  #     uses: softprops/action-gh-release@v1
-  #     with:
-  #       files: totem.ipa
-  #       body: Internal release
-  #   - run: fastlane ios internal
-  #     env:
-  #       APPLE_STORE_CONNECT_API_KEY: ${{ secrets.APPLE_STORE_CONNECT_API_KEY }}
-  # build_android:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - name: Install Flutter
-  #       uses: subosito/flutter-action@v2
-  #       with:
-  #         flutter-version: '3.0.x'
-  #         cache: true
-  #     - name: Setup secrets
-  #       run: |
-  #         echo "$PLAY_KEYSTORE_B64" | base64 --decode > android/keystore.jks
-  #         echo "$PLAY_KEYSTORE_PROPERTIES" > android/key.properties
-  #       env:
-  #         PLAY_KEYSTORE_B64: ${{ secrets.PLAY_KEYSTORE_B64 }}
-  #         PLAY_KEYSTORE_PROPERTIES: ${{ secrets.PLAY_KEYSTORE_PROPERTIES }}
-  #     - run: flutter build appbundle
-  #     - name: Release
-  #       uses: softprops/action-gh-release@v1
-  #       with:
-  #         files: build/app/outputs/bundle/release/app-release.aab
-  #         body: Internal release
-  #     - run: fastlane android internal
-  #       env:
-  #         PLAY_DEPLOY_KEY: ${{ secrets.PLAY_DEPLOY_KEY }}
+  build_ios:
+   runs-on: macos-11
+   steps:
+    - uses: actions/checkout@v2
+    - name: Install Flutter
+      uses: subosito/flutter-action@v2
+      with:
+        flutter-version: '3.0.x'
+        cache: true
+    - uses: webfactory/ssh-agent@v0.5.4
+      with:
+        ssh-private-key: ${{ secrets.MATCH_REPO_PRIVATE_KEY }}
+    - run: fastlane ios build
+      env:
+        MATCH_PASSWORD: ${{ secrets.FASTLANE_MATCH_PASSWORD }}
+    - name: Release
+      uses: softprops/action-gh-release@v1
+      with:
+        files: totem.ipa
+        body: Internal release
+    - run: fastlane ios internal
+      env:
+        APPLE_STORE_CONNECT_API_KEY: ${{ secrets.APPLE_STORE_CONNECT_API_KEY }}
+  build_android:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.0.x'
+          cache: true
+      - name: Setup secrets
+        run: |
+          echo "$PLAY_KEYSTORE_B64" | base64 --decode > android/keystore.jks
+          echo "$PLAY_KEYSTORE_PROPERTIES" > android/key.properties
+        env:
+          PLAY_KEYSTORE_B64: ${{ secrets.PLAY_KEYSTORE_B64 }}
+          PLAY_KEYSTORE_PROPERTIES: ${{ secrets.PLAY_KEYSTORE_PROPERTIES }}
+      - run: flutter build appbundle
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: build/app/outputs/bundle/release/app-release.aab
+          body: Internal release
+      - run: fastlane android internal
+        env:
+          PLAY_DEPLOY_KEY: ${{ secrets.PLAY_DEPLOY_KEY }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,61 +18,61 @@ jobs:
           cache: true
       - run: make build-web
       - run: zip -r web build/web
-      - name: Release
-        uses: softprops/action-gh-release@v1
-        with:
-          files: web.zip
-          body: Internal release
+      # - name: Release
+      #   uses: softprops/action-gh-release@v1
+      #   with:
+      #     files: web.zip
+      #     body: Internal release
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: '${{ secrets.GITHUB_TOKEN }}'
           firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_TOTEM_26659 }}'
           channelId: live
-  build_ios:
-   runs-on: macos-11
-   steps:
-    - uses: actions/checkout@v2
-    - name: Install Flutter
-      uses: subosito/flutter-action@v2
-      with:
-        flutter-version: '3.0.x'
-        cache: true
-    - uses: webfactory/ssh-agent@v0.5.4
-      with:
-        ssh-private-key: ${{ secrets.MATCH_REPO_PRIVATE_KEY }}
-    - run: fastlane ios build
-      env:
-        MATCH_PASSWORD: ${{ secrets.FASTLANE_MATCH_PASSWORD }}
-    - name: Release
-      uses: softprops/action-gh-release@v1
-      with:
-        files: totem.ipa
-        body: Internal release
-    - run: fastlane ios internal
-      env:
-        APPLE_STORE_CONNECT_API_KEY: ${{ secrets.APPLE_STORE_CONNECT_API_KEY }}
-  build_android:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install Flutter
-        uses: subosito/flutter-action@v2
-        with:
-          flutter-version: '3.0.x'
-          cache: true
-      - name: Setup secrets
-        run: |
-          echo "$PLAY_KEYSTORE_B64" | base64 --decode > android/keystore.jks
-          echo "$PLAY_KEYSTORE_PROPERTIES" > android/key.properties
-        env:
-          PLAY_KEYSTORE_B64: ${{ secrets.PLAY_KEYSTORE_B64 }}
-          PLAY_KEYSTORE_PROPERTIES: ${{ secrets.PLAY_KEYSTORE_PROPERTIES }}
-      - run: flutter build appbundle
-      - name: Release
-        uses: softprops/action-gh-release@v1
-        with:
-          files: build/app/outputs/bundle/release/app-release.aab
-          body: Internal release
-      - run: fastlane android internal
-        env:
-          PLAY_DEPLOY_KEY: ${{ secrets.PLAY_DEPLOY_KEY }}
+  # build_ios:
+  #  runs-on: macos-11
+  #  steps:
+  #   - uses: actions/checkout@v2
+  #   - name: Install Flutter
+  #     uses: subosito/flutter-action@v2
+  #     with:
+  #       flutter-version: '3.0.x'
+  #       cache: true
+  #   - uses: webfactory/ssh-agent@v0.5.4
+  #     with:
+  #       ssh-private-key: ${{ secrets.MATCH_REPO_PRIVATE_KEY }}
+  #   - run: fastlane ios build
+  #     env:
+  #       MATCH_PASSWORD: ${{ secrets.FASTLANE_MATCH_PASSWORD }}
+  #   - name: Release
+  #     uses: softprops/action-gh-release@v1
+  #     with:
+  #       files: totem.ipa
+  #       body: Internal release
+  #   - run: fastlane ios internal
+  #     env:
+  #       APPLE_STORE_CONNECT_API_KEY: ${{ secrets.APPLE_STORE_CONNECT_API_KEY }}
+  # build_android:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Install Flutter
+  #       uses: subosito/flutter-action@v2
+  #       with:
+  #         flutter-version: '3.0.x'
+  #         cache: true
+  #     - name: Setup secrets
+  #       run: |
+  #         echo "$PLAY_KEYSTORE_B64" | base64 --decode > android/keystore.jks
+  #         echo "$PLAY_KEYSTORE_PROPERTIES" > android/key.properties
+  #       env:
+  #         PLAY_KEYSTORE_B64: ${{ secrets.PLAY_KEYSTORE_B64 }}
+  #         PLAY_KEYSTORE_PROPERTIES: ${{ secrets.PLAY_KEYSTORE_PROPERTIES }}
+  #     - run: flutter build appbundle
+  #     - name: Release
+  #       uses: softprops/action-gh-release@v1
+  #       with:
+  #         files: build/app/outputs/bundle/release/app-release.aab
+  #         body: Internal release
+  #     - run: fastlane android internal
+  #       env:
+  #         PLAY_DEPLOY_KEY: ${{ secrets.PLAY_DEPLOY_KEY }}

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,6 @@ publish-ios:
 	fastlane ios internal
 
 build-web: clean
-	rm -rf build/web
 	flutter build web --release
 
 publish-web: build-web

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# totem
+# Totem
+Bringing people together to heal.
 
 ## Requirements
 - flutter
@@ -9,20 +10,16 @@
 ## Setup
 1. Run `make install_hooks` to make sure no secrets are committed.
 
-## Release Mobile
+## Release
 
-1. Switch to 'main' branch.
+1. Switch to 'main' branch: `git checkout main`
 1. Edit `pubspec.yaml` to increase the version number. At minimum bump the build number (after the `+`).
 1. Create a commit with your changes. Usually in the form of `git commit -m "v1.4.2+15"`
-1. Run `make release`.
+1. Run `make release`. This adds a tag with the version number and pushes everything online.
+1. Soon, the web code will be live: https://app.heytotem.com/
 1. Then, when happy with it, you need to promote the Android build in the Play console (https://play.google.com/console/u/0/developers/6048825475784314007/app/4973577798809786425/tracks/4699484839665024268/releases/11/prepare)
 1. Additionally, the iOS app needs to be released to external testers at (https://appstoreconnect.apple.com/apps/1591746908/testflight/groups/d57a217c-7e77-4865-98a4-c663ac913bd1)
 1. Archive the `Done` tickets: https://github.com/orgs/totem-technologies/projects/1/views/1
-
-## Release Web
-
-1. Run `make publish-web`
-1. Make sure (https://app.heytotem.com/) loads
 
 ## iOS build notes
 


### PR DESCRIPTION
Fully automated release for web in CI! It takes about 3 minutes from running `make release` to live code. It also archives web.zip in GitHub Releases in case we need to debug or deploy locally. 

We're not auto release on merge because I've seen that go sideways before when multiple merges are required to make a working app.

I'd love to see someone else try to release and get some feedback on the process and instructions. 