### PR TITLE
Use permissions and rules for snap circles

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,31 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "totem",
+      "request": "launch",
+      "type": "dart"
+    },
+    {
+      "name": "totem (profile mode)",
+      "request": "launch",
+      "type": "dart",
+      "flutterMode": "profile"
+    },
+    {
+      "name": "totem (release mode)",
+      "request": "launch",
+      "type": "dart",
+      "flutterMode": "release"
+    },
+    {
+      "name": "totem (firebase emulator)",
+      "request": "launch",
+      "type": "dart",
+      "args": ["--dart-define=USE_EMULATOR=true"]
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -10,6 +10,19 @@ Bringing people together to heal.
 ## Setup
 1. Run `make install_hooks` to make sure no secrets are committed.
 
+## Firebase emulator
+
+1. You will need to run this command once:
+   - `cd server/functions; firebase functions:config:get > .runtimeconfig.json`
+   - ***NOTE:*** This file should never be checked in as it contains secrets (it's in the .gitignore)
+2. Start the local firebase emulator:
+   - From the terminal: `cd server/functions; npm run serve`
+   - From VSCode click the start button next to the "serve" line under 'NPM Scripts'
+3. Run the totem flutter application with the environment variable `USE_EMULATOR=true`
+   - For VSCode there is a checked in configuration in the `launch.json` file.
+   - For Android Studio, create a new configuration with the run args `--dart-define=USE_EMULATOR=true`
+4. Since the emulator runs on localhost, you will need to either use web or a device emulator as the target device.
+
 ## Release
 
 1. Switch to 'main' branch: `git checkout main`

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,7 +1,11 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:cloud_functions/cloud_functions.dart';
 import 'package:firebase_app_check/firebase_app_check.dart';
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_crashlytics/firebase_crashlytics.dart';
-import 'package:flutter/foundation.dart' show kDebugMode, kIsWeb;
+import 'package:flutter/foundation.dart'
+    show kDebugMode, kIsWeb, defaultTargetPlatform;
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -13,6 +17,10 @@ import 'package:totem/config.dart';
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await Firebase.initializeApp(options: DefaultFirebaseOptions.currentPlatform);
+
+  if (const String.fromEnvironment('USE_EMULATOR') == 'true') {
+    await _connectToFirebaseEmulator();
+  }
   // remove # from url
   GoRouter.setUrlPathStrategy(UrlPathStrategy.path);
 
@@ -54,4 +62,18 @@ Future<void> main() async {
       ));
     },
   );
+}
+
+Future _connectToFirebaseEmulator() async {
+  final emulatorHost = defaultTargetPlatform == TargetPlatform.android
+      ? '10.0.2.2'
+      : 'localhost';
+
+  FirebaseFirestore.instance.settings = Settings(
+    host: '$emulatorHost:8080',
+    sslEnabled: false,
+    persistenceEnabled: false,
+  );
+  FirebaseFunctions.instance.useFunctionsEmulator(emulatorHost, 5001);
+  await FirebaseAuth.instance.useAuthEmulator(emulatorHost, 9099);
 }

--- a/lib/models/circle.dart
+++ b/lib/models/circle.dart
@@ -12,7 +12,7 @@ abstract class Circle {
   String? activeSession;
   int participantCount = 0;
   String? link;
-  String? keeper;
+  late String keeper;
   String? previousCircle;
   List<String>? removedParticipants;
   bool _canJoin = true;
@@ -42,7 +42,9 @@ abstract class Circle {
 
   bool get canJoin => _canJoin;
 
-  Role participantRole(String participantId);
+  Role participantRole(String participantId) {
+    return keeper == participantId ? Role.keeper : Role.member;
+  }
 
   Map<String, dynamic> toJson() {
     Map<String, dynamic> data = {

--- a/lib/models/snap_circle.dart
+++ b/lib/models/snap_circle.dart
@@ -37,14 +37,6 @@ class SnapCircle extends Circle {
   }
 
   @override
-  Role participantRole(String participantId) {
-    if (createdBy != null && createdBy!.uid == participantId) {
-      return Role.keeper;
-    }
-    return Role.member;
-  }
-
-  @override
   Map<String, dynamic> toJson({bool includeParticipants = true}) {
     Map<String, dynamic> data = super.toJson();
     data["state"] = state.name;

--- a/lib/services/firebase_providers/firebase_session_provider.dart
+++ b/lib/services/firebase_providers/firebase_session_provider.dart
@@ -463,8 +463,6 @@ class FirebaseSessionProvider extends SessionProvider {
             sessionData['participants'] = participants;
             sessionData['userStatus'] = false;
             transaction.update(ref, sessionData);
-            int count = participants.length;
-            transaction.update(circleRef, {'participantCount': count});
           }
         }
       }
@@ -511,8 +509,6 @@ class FirebaseSessionProvider extends SessionProvider {
       String sessionUserId, String? sessionImage,
       {bool muted = false, bool videoMuted = false}) async {
     await FirebaseFirestore.instance.runTransaction((transaction) async {
-      DocumentReference circleRef =
-          FirebaseFirestore.instance.doc(session.circle.ref);
       DocumentReference activeCircleRef = FirebaseFirestore.instance
           .collection(Paths.activeCircles)
           .doc(session.circle.id);
@@ -571,9 +567,6 @@ class FirebaseSessionProvider extends SessionProvider {
         activeSession["speakingOrder"] = speakingOrder;
         activeSession["userStatus"] = false;
         transaction.update(activeCircleRef, activeSession);
-
-        int count = (participants.length);
-        transaction.update(circleRef, {"participantCount": count});
       }
     });
     return true;

--- a/server/firestore.rules
+++ b/server/firestore.rules
@@ -19,18 +19,28 @@ service cloud.firestore {
       allow read: if request.auth != null;
       allow write: if request.auth != null && isDocOwner(uid);
     }
-    match /circles/{circleId}/{documents=**} {
+    match /circles/{circleId} {
       allow read: if request.auth != null;
-      allow write: if request.auth != null; // Fix me - should be role based/Testing only
+      allow create: if hasAnyRole(["keeper"]);
+      match /{documents=**} {
+        allow read: if request.auth != null;
+        allow write: if isDocOwner(resource.data.keeper); // Only circle keeper can update
+      }
     }
-    match /snapCircles/{circleId}/{documents=**} {
+    match /snapCircles/{circleId} {
       allow read: if request.auth != null;
-      allow write: if request.auth != null; // Fix me - should be role based/Testing only
+      allow create: if false; // Only created by cloud function
+      match /{documents=**} {
+        allow read: if request.auth != null;
+        allow write: if isDocOwner(resource.data.keeper); // Only circle keeper can update
+      }
     }
     match /activeCircles/{circleId}/{documents=**} {
       allow read: if request.auth != null;
-      allow write: if request.auth != null; // Fix me - should be role based/Testing only
+      allow write: if request.auth != null;
     }
-
+		match /system/{type}/{documents=**} {
+      allow read: if request.auth != null;
+    }
   }
 }

--- a/server/functions/package.json
+++ b/server/functions/package.json
@@ -3,7 +3,7 @@
   "scripts": {
     "lint": "eslint --ext .js,.ts .",
     "build": "tsc",
-    "serve": "npm run build && firebase emulators:start --only functions",
+    "serve": "npm run build -- --watch | firebase emulators:start",
     "shell": "npm run build && firebase functions:shell",
     "start": "npm run shell",
     "test": "mocha -r ts-node/register --reporter spec test/**/*.ts",

--- a/server/functions/src/auth.ts
+++ b/server/functions/src/auth.ts
@@ -1,14 +1,39 @@
 import * as functions from "firebase-functions";
 import {AuthData} from "firebase-functions/lib/common/providers/https";
 
+export enum Role {
+  MEMBER = "member",
+  KEEPER = "keeper",
+  ADMIN = "admin",
+}
+
 /**
  * Checks if the `auth` object exists, and has a uid. Returns a non-null auth object.
  * @param {AuthData | undefined} auth
+ * @param {Role[] | undefined} roles
  * @return {AuthData}
  */
-export function isAuthenticated(auth: AuthData | undefined): AuthData {
+export function isAuthenticated(auth: AuthData | undefined, roles: Role[] | undefined = undefined): AuthData {
   if (!auth || !auth.uid) {
     throw new functions.https.HttpsError("failed-precondition", "The function must be called while authenticated.");
   }
+  if (roles && roles.length > 0) {
+    if (!hasAnyRole(auth, roles)) {
+      throw new functions.https.HttpsError(
+        "failed-precondition",
+        `The function must be called by a user with one of the roles: ${roles.join(", ")}.`
+      );
+    }
+  }
   return auth;
+}
+
+/**
+ * Checks to see if the user has any of the roles in the `roles` array.
+ * @param {AuthData} auth
+ * @param {Role[]} roles
+ * @return {boolean}
+ */
+export function hasAnyRole(auth: AuthData, roles: Role[]): boolean {
+  return auth.token.roles && roles.some((r) => auth.token.roles.includes(r));
 }

--- a/server/functions/src/session.ts
+++ b/server/functions/src/session.ts
@@ -1,7 +1,9 @@
 import * as functions from "firebase-functions";
 import * as admin from "firebase-admin";
+// eslint-disable-next-line import/no-unresolved
+import {Timestamp} from "firebase-admin/firestore";
 import * as dynamicLinks from "./dynamic-links";
-import {isAuthenticated} from "./auth";
+import {hasAnyRole, isAuthenticated, Role} from "./auth";
 
 // The Firebase Admin SDK to access the Firebase Realtime Database.
 // make sure that this initializeApp call hasn't already
@@ -24,13 +26,19 @@ const SessionState = {
 };
 
 export const endSnapSession = functions.https.onCall(async ({circleId}, {auth}) => {
-  isAuthenticated(auth);
+  auth = isAuthenticated(auth);
   if (circleId) {
     const circleRef = admin.firestore().collection("snapCircles").doc(circleId);
     const circleSnapshot = await circleRef.get();
     if (circleSnapshot.exists) {
       const {circleParticipants, state, keeper} = circleSnapshot.data() ?? {};
-      const completedDate = admin.firestore.Timestamp.fromDate(new Date());
+      if (auth.uid !== keeper && !hasAnyRole(auth, [Role.ADMIN])) {
+        throw new functions.https.HttpsError(
+          "failed-precondition",
+          "The function can only be called by the keeper of the circle or an admin."
+        );
+      }
+      const completedDate = Timestamp.now();
       const batch = admin.firestore().batch();
       let endState = SessionState.cancelled;
       if (state === SessionState.ending) {
@@ -39,9 +47,9 @@ export const endSnapSession = functions.https.onCall(async ({circleId}, {auth}) 
         // moving from current state of 'active' to complete means the session is done
         // only cache the circle in users list if it was active
         if (circleParticipants) {
-          circleParticipants.forEach((uid: string)=>{
+          circleParticipants.forEach((uid: string) => {
             const entryRef = admin.firestore().collection("users").doc(uid).collection("snapCircles").doc();
-            const role = (keeper === uid) ? "keeper" : "member";
+            const role = keeper === uid ? "keeper" : "member";
             batch.set(entryRef, {...entry, role, completedDate});
           });
         }
@@ -60,12 +68,18 @@ export const endSnapSession = functions.https.onCall(async ({circleId}, {auth}) 
 });
 
 export const startSnapSession = functions.https.onCall(async ({circleId}, {auth}) => {
-  isAuthenticated(auth);
+  auth = isAuthenticated(auth);
   if (circleId) {
     const ref = admin.firestore().collection("snapCircles").doc(circleId);
     const circleSnapshot = await ref.get();
     if (circleSnapshot.exists) {
-      const {state} = circleSnapshot.data() ?? {};
+      const {state, keeper} = circleSnapshot.data() ?? {};
+      if (auth.uid !== keeper) {
+        throw new functions.https.HttpsError(
+          "failed-precondition",
+          "The function can only be called by the keeper of the circle."
+        );
+      }
       if (state === SessionState.starting) {
         let sessionParticipants = {};
 
@@ -86,20 +100,15 @@ export const startSnapSession = functions.https.onCall(async ({circleId}, {auth}
         });
         // store the participants, but store them keyed by uid so it
         // can be looked up in case of need to rejoin
-        let keeper = "";
         const circleParticipants: string[] = [];
         Object.entries(sessionParticipants).forEach(([, value]) => {
           const uid: string = <string>(<Record<string, unknown>>value).uid;
-          const role: string = <string>(<Record<string, unknown>>value).role;
-          if (role === "keeper") {
-            keeper = uid;
-          }
           circleParticipants.push(uid);
         });
         // cache the participants at the circle level as an archive of the users that
         // are part of the started session
-        const startedDate = admin.firestore.Timestamp.fromDate(new Date());
-        ref.update({state: SessionState.live, startedDate, circleParticipants, keeper});
+        const startedDate = Timestamp.now();
+        ref.update({state: SessionState.live, startedDate, circleParticipants});
         return true;
       }
     }
@@ -107,75 +116,92 @@ export const startSnapSession = functions.https.onCall(async ({circleId}, {auth}
   return false;
 });
 
-export const createSnapCircle = functions.https.onCall(async ({name, description, keeper, previousCircle, removedParticipants}, {auth}) => {
-  auth = isAuthenticated(auth);
-  if (!name) {
-    throw new functions.https.HttpsError("failed-precondition", "Missing name for snap circle");
-  }
-  // Get the user ref
-  const creatorId = keeper || auth.uid;
-  const userRef = admin.firestore().collection("users").doc(creatorId);
+export const createSnapCircle = functions.https.onCall(
+  async ({name, description, previousCircle, removedParticipants}, {auth}) => {
+    auth = isAuthenticated(auth, [Role.KEEPER]);
+    if (!name) {
+      throw new functions.https.HttpsError("failed-precondition", "Missing name for snap circle");
+    }
+    // Get the user ref
+    const keeper = auth.uid;
+    const userRef = admin.firestore().collection("users").doc(keeper);
 
-  // Enable this block eventually to check for the proper permission for the user trying to create
-  // the circle, currently anyone can create a snap circle
-  /*
-  const userSnapshot = await userRef.get();
-  const { role } = (userSnapshot.exists ? (user.data() ?? {}) : {};
-  if (!role  || role != 'keeper') {
-      throw new functions.https.HttpsError("failed-precondition", "No permission to create snap circle");
-  } */
-  const created = admin.firestore.Timestamp.fromDate(new Date());
-  const data : {name: string;
-    createdOn: admin.firestore.Timestamp,
-    updatedOn: admin.firestore.Timestamp,
-    createdBy: admin.firestore.DocumentReference,
-    state: string,
-    description?: string,
-    link?: string,
-    previousCircle?: string,
-    removedParticipants?: string[],
-  } = {
-    name,
-    createdOn: created,
-    updatedOn: created,
-    createdBy: userRef,
-    state: SessionState.waiting,
-  };
-  if (description) {
-    data.description = description;
-  }
-  if (previousCircle) {
-    data.previousCircle = previousCircle;
-  }
-  if (removedParticipants) {
-    data.removedParticipants = removedParticipants;
-  }
-  const ref = await admin.firestore().collection("snapCircles").add(data);
-  await admin.firestore().collection("activeCircles").doc(ref.id).set({participants: {}});
-  // Generate a dynamic link for this circle
-  try {
-    const {shortLink, previewLink} = await firebaseDynamicLinks.createLink({
-      dynamicLinkInfo: {
-        domainUriPrefix: functions.config().applinks.link,
-        link: "https://app.heytotem.com/?snap=" + ref.id,
-        androidInfo: {
-          androidPackageName: "io.kbl.totem",
+    const created = Timestamp.now();
+    const data: {
+      name: string;
+      createdOn: Timestamp;
+      updatedOn: Timestamp;
+      createdBy: admin.firestore.DocumentReference;
+      keeper: string;
+      state: string;
+      description?: string;
+      link?: string;
+      previousCircle?: string;
+      removedParticipants?: string[];
+    } = {
+      name,
+      createdOn: created,
+      updatedOn: created,
+      createdBy: userRef,
+      keeper,
+      state: SessionState.waiting,
+    };
+    if (description) {
+      data.description = description;
+    }
+    if (previousCircle) {
+      data.previousCircle = previousCircle;
+    }
+    if (removedParticipants) {
+      data.removedParticipants = removedParticipants;
+    }
+    const ref = await admin.firestore().collection("snapCircles").add(data);
+    await admin.firestore().collection("activeCircles").doc(ref.id).set({participants: {}});
+    // Generate a dynamic link for this circle
+    try {
+      const {shortLink, previewLink} = await firebaseDynamicLinks.createLink(
+        {
+          dynamicLinkInfo: {
+            domainUriPrefix: functions.config().applinks.link,
+            link: "https://app.heytotem.com/?snap=" + ref.id,
+            androidInfo: {
+              androidPackageName: "io.kbl.totem",
+            },
+            iosInfo: {
+              iosBundleId: "io.kbl.totem",
+            },
+          },
+          suffix: {
+            option: "UNGUESSABLE",
+          },
         },
-        iosInfo: {
-          iosBundleId: "io.kbl.totem",
-        },
-      },
-      suffix: {
-        option: "UNGUESSABLE",
-      },
-    }, "createSnapCircle");
-    // update with the link
-    await admin.firestore().collection("snapCircles").doc(ref.id).update({link: shortLink, previewLink});
-  } catch (ex) {
-    console.log(ex);
+        "createSnapCircle"
+      );
+      // update with the link
+      await admin.firestore().collection("snapCircles").doc(ref.id).update({link: shortLink, previewLink});
+    } catch (ex) {
+      console.log(ex);
+    }
+    // return information
+    return {id: ref.id};
   }
-  // return information
-  return {id: ref.id};
-});
+);
 
-
+/**
+ * Update the snap circle with the new participant count when active session is updated
+ * The activeCircle is updated by a normal member, but snapCircles can only be updated by the keeper
+ * @param circleId The id of the circle to update
+ */
+export const updateParticipants = functions.firestore
+  .document("activeCircles/{circleId}")
+  .onUpdate(async (change, context) => {
+    const {circleId} = context.params;
+    const {participants: participantsBefore} = change.before.data() ?? {};
+    const {participants: participantsAfter} = change.after.data() ?? {};
+    const numBefore = Object.keys(participantsBefore).length;
+    const numAfter = Object.keys(participantsAfter).length;
+    if (numAfter !== numBefore) {
+      const ref = admin.firestore().collection("snapCircles").doc(circleId);
+      await ref.update({participantCount: numAfter});
+    }
+  });


### PR DESCRIPTION
For issue #265 
Backend:
- Update `firestore.rules` to restrict creating circles to only the cloud function and editing circle data to the designated "keeper"
- Add a new auth function for checking that an authenticated user has one of a specified set of roles.
- Restrict calling `createSnapCircle()` to users with the "keeper" role.
- Set the "keeper" field in the circle to the creating user (don't set it when starting circle)
- Restrict calling `start/endSnapCircle()` to the user who is specified as the "keeper" for the circle.
- Add cloud function to update the participant count in a circle when a user adds themself to the associated activeCircle

Frontend:
- Don't assume circle role based on creation but directly from the "keeper" field in the circle data
- Don't update the circle `participantCount` from the frontend since it is in protected data now

Firebase Emulator Support:
- Update `package.json` to run the local emulator for the "serve" target
- Update client `main.dart` to connect to local emulator based on an environment variable
- Update the `README.md` to explain how to run against the local emulator