### PR TITLE
Fix Pass Help Text

### DIFF
--- a/i18n/app_en.arb
+++ b/i18n/app_en.arb
@@ -46,7 +46,7 @@
     },
     "circleReturnToApp": "Tap to return to Totem",
     "circleStarting": "Circle is starting",
-    "circleTotemPass": "Skips sharing by:",
+    "circleTotemPass": "Finishes sharing by:",
     "circleTotemPassLine1": "muting microphone",
     "circleTotemPassLine2": "hiding video or image",
     "circleTotemPassLine3": "passing to next person",


### PR DESCRIPTION
Makes the help text for the Pass button tooltip meaningful when moved to it's new UI location