### PR TITLE
Workflow on user private circles

### DIFF
--- a/i18n/app_en.arb
+++ b/i18n/app_en.arb
@@ -259,5 +259,6 @@
     "worksBestChrome": "This works best in Chrome browsers",
     "yes": "Yes",
     "youAreSharing": "You are sharing",
+    "yourPrivateCircles": "Your private circles",
     "yourTurn": "Your Turn"
   }

--- a/lib/app/circle/circle_session_page.dart
+++ b/lib/app/circle/circle_session_page.dart
@@ -159,13 +159,19 @@ class CircleSessionPageState extends ConsumerState<CircleSessionPage>
               [SessionState.waiting, SessionState.starting, SessionState.live]);
           if (pending == null) {
             // this is a create new circle moment
-            circle = await repo.createSnapCircle(
-              name: circle.name,
-              description: circle.description,
-              keeper: circle.keeper,
-              previousCircle: circle.id,
-              bannedParticipants: circle.bannedParticipants,
-            );
+            try {
+              circle = await repo.createSnapCircle(
+                name: circle.name,
+                description: circle.description,
+                keeper: circle.keeper,
+                previousCircle: circle.id,
+                bannedParticipants: circle.bannedParticipants,
+              );
+            } on ServiceException catch (ex) {
+              debugPrint('Error re-creating circle: $ex');
+              setState(() => _sessionState = SessionPageState.error);
+              return;
+            }
           } else {
             // join the pending one
             circle = pending;

--- a/lib/app/home/components/named_circle_list.dart
+++ b/lib/app/home/components/named_circle_list.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:totem/app_routes.dart';
+import 'package:totem/models/snap_circle.dart';
+import 'package:totem/theme/index.dart';
+
+import 'snap_circle_item.dart';
+
+class NamedCircleList extends ConsumerWidget {
+  const NamedCircleList({Key? key, required this.name, required this.circles})
+      : super(key: key);
+  final String name;
+  final List<SnapCircle> circles;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Padding(
+          padding: EdgeInsets.symmetric(
+              horizontal: Theme.of(context).pageHorizontalPadding),
+          child: Text(
+            name,
+            style: Theme.of(context).textStyles.headline2,
+          ),
+        ),
+        const SizedBox(
+          height: 10,
+        ),
+        ListView.builder(
+          shrinkWrap: true,
+          padding: const EdgeInsets.only(bottom: 8, top: 8),
+          itemCount: circles.length,
+          itemBuilder: (c, i) => SnapCircleItem(
+            circle: circles[i],
+            onPressed: (circle) => _handleShowCircle(context, circle),
+          ),
+        ),
+        Padding(
+          padding: EdgeInsets.symmetric(
+              vertical: 8.0,
+              horizontal: Theme.of(context).pageHorizontalPadding),
+          child: Divider(
+            height: 1,
+            thickness: 1,
+            color: Theme.of(context).themeColors.divider,
+          ),
+        ),
+      ],
+    );
+  }
+
+  void _handleShowCircle(BuildContext context, SnapCircle circle) {
+    context.goNamed(AppRoutes.circle, params: {'id': circle.snapSession.id});
+  }
+}

--- a/lib/services/circles_provider.dart
+++ b/lib/services/circles_provider.dart
@@ -4,8 +4,9 @@ abstract class CirclesProvider {
   Stream<List<ScheduledCircle>> scheduledCircles(String? uid);
 
   Stream<List<SnapCircle>> snapCircles();
-
   Stream<List<SnapCircle>> rejoinableSnapCircles(String uid);
+  Stream<List<SnapCircle>> mySnapCircles(
+      String uid, {bool privateOnly, bool activeOnly});
 
   Future<ScheduledCircle?> createScheduledCircle({
     required String name,

--- a/lib/services/totem_repository.dart
+++ b/lib/services/totem_repository.dart
@@ -96,6 +96,10 @@ class TotemRepository {
   Stream<List<SnapCircle>> snapCircles() => _circlesProvider.snapCircles();
   Stream<List<SnapCircle>> rejoinableSnapCircles() =>
       _circlesProvider.rejoinableSnapCircles(user!.uid);
+  Stream<List<SnapCircle>> mySnapCircles(
+          {bool privateOnly = true, bool activeOnly = true}) =>
+      _circlesProvider.mySnapCircles(user!.uid,
+          privateOnly: privateOnly, activeOnly: activeOnly);
   Stream<ScheduledCircle> scheduledCircle({required String circleId}) =>
       _circlesProvider.scheduledCircle(circleId, user!.uid);
   Future<SnapCircle?> circleFromId(String id) =>

--- a/server/functions/package-lock.json
+++ b/server/functions/package-lock.json
@@ -9,7 +9,7 @@
         "agora-access-token": "^2.0.4",
         "axios": "^0.27.2",
         "firebase-admin": "^11.0.0",
-        "firebase-functions": "^3.22.0"
+        "firebase-functions": "^3.23.0"
       },
       "devDependencies": {
         "@types/chai": "^4.2.22",

--- a/server/functions/package.json
+++ b/server/functions/package.json
@@ -18,7 +18,7 @@
     "agora-access-token": "^2.0.4",
     "axios": "^0.27.2",
     "firebase-admin": "^11.0.0",
-    "firebase-functions": "^3.22.0"
+    "firebase-functions": "^3.23.0"
   },
   "devDependencies": {
     "@types/chai": "^4.2.22",

--- a/server/functions/src/common-types.ts
+++ b/server/functions/src/common-types.ts
@@ -1,0 +1,28 @@
+// eslint-disable-next-line import/no-unresolved -- https://github.com/firebase/firebase-admin-node/issues/1827#issuecomment-1226224988
+import {Timestamp} from "firebase-admin/firestore";
+import * as admin from "firebase-admin";
+
+export interface SnapCircleBannedParticipants {
+  [uid: string]: {
+    bannedOn: Timestamp;
+    sessionBan?: {sessionUserId: string; ruleId: number};
+  };
+}
+
+export interface SnapCircleData {
+  name: string;
+  createdOn: Timestamp;
+  updatedOn: Timestamp;
+  createdBy: admin.firestore.DocumentReference;
+  isPrivate: boolean;
+  maxMinutes?: number;
+  maxParticipants?: number;
+  keeper: string;
+  state: string;
+  description?: string;
+  link?: string;
+  previousCircle?: string;
+  participantCount?: number;
+  circleParticipants?: string[];
+  bannedParticipants?: SnapCircleBannedParticipants;
+}

--- a/server/functions/src/session.ts
+++ b/server/functions/src/session.ts
@@ -5,6 +5,7 @@ import {Timestamp} from "firebase-admin/firestore";
 import * as dynamicLinks from "./dynamic-links";
 import {hasAnyRole, isAuthenticated, Role} from "./auth";
 import {kickUserFromSession} from "./agora";
+import {SnapCircleBannedParticipants, SnapCircleData} from "./common-types";
 
 // The Firebase Admin SDK to access the Firebase Realtime Database.
 // make sure that this initializeApp call hasn't already
@@ -26,13 +27,16 @@ const SessionState = {
   ending: "ending",
 };
 
+const NonKeeperMaxMinutes = 500;
+const NonKeeperMaxParticipants = 10;
+
 export const endSnapSession = functions.https.onCall(async ({circleId}, {auth}): Promise<boolean> => {
   auth = isAuthenticated(auth);
   if (circleId) {
     const circleRef = admin.firestore().collection("snapCircles").doc(circleId);
     const circleSnapshot = await circleRef.get();
     if (circleSnapshot.exists) {
-      const {circleParticipants, state, keeper} = circleSnapshot.data() ?? {};
+      const {circleParticipants, state, keeper} = (circleSnapshot.data() as SnapCircleData) ?? {};
       if (auth.uid !== keeper && !hasAnyRole(auth, [Role.ADMIN])) {
         throw new functions.https.HttpsError(
           "permission-denied",
@@ -74,7 +78,7 @@ export const startSnapSession = functions.https.onCall(async ({circleId}, {auth}
     const ref = admin.firestore().collection("snapCircles").doc(circleId);
     const circleSnapshot = await ref.get();
     if (circleSnapshot.exists) {
-      const {state, keeper} = circleSnapshot.data() ?? {};
+      const {state, keeper} = (circleSnapshot.data() as SnapCircleData) ?? {};
       if (auth.uid !== keeper) {
         throw new functions.https.HttpsError(
           "permission-denied",
@@ -117,40 +121,70 @@ export const startSnapSession = functions.https.onCall(async ({circleId}, {auth}
   return false;
 });
 
-interface SnapCircleResponse {
+interface CreateSnapCircleArgs {
+  name: string;
+  description: string;
+  previousCircle?: string;
+  bannedParticipants?: SnapCircleBannedParticipants;
+  options?: {
+    isPrivate: boolean;
+    maxMinutes?: number;
+    maxParticipants?: number;
+  };
+}
+
+interface CreateSnapCircleResponse {
   id: string;
 }
 
 export const createSnapCircle = functions.https.onCall(
-  async ({name, description, previousCircle, bannedParticipants}, {auth}): Promise<SnapCircleResponse> => {
-    auth = isAuthenticated(auth, [Role.KEEPER]);
+  async (
+    {name, description, previousCircle, bannedParticipants, options}: CreateSnapCircleArgs,
+    {auth}
+  ): Promise<CreateSnapCircleResponse> => {
+    auth = isAuthenticated(auth);
     if (!name) {
       throw new functions.https.HttpsError("invalid-argument", "Missing name for snap circle");
     }
+
+    if (!hasAnyRole(auth, [Role.KEEPER])) {
+      // Non-keeper circles can't be re-started
+      if (previousCircle) {
+        throw new functions.https.HttpsError("permission-denied", "This circle has ended and cannot be re-started.");
+      }
+      // Non-keepers can only have one active circle
+      await assertHasFewerCirclesThan(auth.uid, 1);
+      // Non-keeper circles can only have a max of 10 participants and must be private
+      options = {
+        isPrivate: true,
+        maxMinutes: NonKeeperMaxMinutes,
+        maxParticipants: NonKeeperMaxParticipants,
+      };
+    } else if (previousCircle) {
+      // Only the keeper can re-start a circle
+      await assertIsCircleKeeper(auth.uid, previousCircle);
+    }
+
     // Get the user ref
     const keeper = auth.uid;
     const userRef = admin.firestore().collection("users").doc(keeper);
 
     const created = Timestamp.now();
-    const data: {
-      name: string;
-      createdOn: Timestamp;
-      updatedOn: Timestamp;
-      createdBy: admin.firestore.DocumentReference;
-      keeper: string;
-      state: string;
-      description?: string;
-      link?: string;
-      previousCircle?: string;
-      bannedParticipants?: Map<string, {bannedOn: Timestamp}>;
-    } = {
+    const data: SnapCircleData = {
       name,
       createdOn: created,
       updatedOn: created,
       createdBy: userRef,
+      isPrivate: options?.isPrivate ?? false,
       keeper,
       state: SessionState.waiting,
     };
+    if (options?.maxMinutes) {
+      data.maxMinutes = options.maxMinutes;
+    }
+    if (options?.maxParticipants) {
+      data.maxParticipants = options.maxParticipants;
+    }
     if (description) {
       data.description = description;
     }
@@ -185,12 +219,35 @@ export const createSnapCircle = functions.https.onCall(
       // update with the link
       await admin.firestore().collection("snapCircles").doc(ref.id).update({link: shortLink, previewLink});
     } catch (ex) {
-      console.log(ex);
+      console.log("Failed to create dynamic link for circle ${ref.id}: ", ex);
     }
     // return information
     return {id: ref.id};
   }
 );
+
+const assertHasFewerCirclesThan = async (uid: string, maxCircles: number): Promise<void> => {
+  const ref = admin
+    .firestore()
+    .collection("snapCircles")
+    .where("keeper", "==", uid)
+    .where("state", "not-in", [SessionState.cancelled, SessionState.complete]);
+  const snapshot = await ref.get();
+  if (snapshot.size >= maxCircles) {
+    throw new functions.https.HttpsError("permission-denied", "You have reached the maximum number of circles");
+  }
+};
+
+const assertIsCircleKeeper = async (uid: string, circleId: string): Promise<void> => {
+  const ref = admin.firestore().collection("snapCircles").doc(circleId);
+  const snapshot = await ref.get();
+  if (!snapshot.exists) {
+    throw new functions.https.HttpsError("not-found", "Circle not found");
+  }
+  if (snapshot.data()?.keeper !== uid) {
+    throw new functions.https.HttpsError("permission-denied", "You are not the keeper of this circle");
+  }
+};
 
 /**
  * Kicks the current session user id out of the agora session and bans the user from joining the circle again


### PR DESCRIPTION
Backend:
- Add `options` argument to `createSnapCircle`
- Default options for non-keepers to be private with limited users/time
- Non-keepers cannot re-start completed circles
- Only previous keeper can re-start a circle
- When joining a circle enforce `maxParticipants` 

Frontend:
- Only list non-private circles in the active list
- Add service interface for getting list of circles you created (can be limited to `privateOnly` and/or `activeOnly`)
- Improve error handling when trying to join circles via link
- Enable Create Circle button for non-keepers if they have no active created circles
- Display "Your private circles" for any private circles the user created that haven't yet been started (started circles will show in the "Re-joinable" list