### PR TITLE
Fix issue with endSnapCircle

### DIFF
--- a/lib/models/active_session.dart
+++ b/lib/models/active_session.dart
@@ -13,6 +13,8 @@ enum SessionState {
   cancelled,
   idle,
   removed,
+  expiring,
+  expired
 }
 
 enum ActiveSessionChange {

--- a/lib/services/firebase_providers/firebase_session_provider.dart
+++ b/lib/services/firebase_providers/firebase_session_provider.dart
@@ -219,7 +219,18 @@ class FirebaseSessionProvider extends SessionProvider {
   @override
   Future<void> endActiveSession() async {
     if (_activeSession != null) {
-      bool complete = _activeSession!.state == SessionState.live;
+      List<SessionState> validStates = [
+        SessionState.waiting,
+        SessionState.starting,
+        SessionState.live,
+        SessionState.expiring,
+      ];
+
+      if (!validStates.contains(_activeSession!.state)) {
+        return;
+      }
+      bool complete = _activeSession!.state == SessionState.live ||
+          _activeSession!.state == SessionState.expiring;
       try {
         await updateActiveSessionState(
             complete ? SessionState.ending : SessionState.cancelling);

--- a/server/functions/src/common-types.ts
+++ b/server/functions/src/common-types.ts
@@ -2,6 +2,7 @@
 import {DocumentReference, Timestamp} from "firebase-admin/firestore";
 
 export enum SessionState {
+  cancelling = "cancelling",
   cancelled = "cancelled",
   complete = "complete",
   live = "live",


### PR DESCRIPTION
Backend:
- Make sure we don't try to write an undefined value
- Only perform end logic if session was active
- Add in "cancelling" state Frontend:
- Don't call backend if session isn't active.
- Handle "expiring" state