### PR TITLE
Avoid abrupt end to expired session

### DIFF
--- a/lib/app/circle/circle_info_dialog.dart
+++ b/lib/app/circle/circle_info_dialog.dart
@@ -404,7 +404,8 @@ class _CircleInfoDialogState extends ConsumerState<CircleInfoDialog> {
     final List<SessionState> validStates = [
       SessionState.waiting,
       SessionState.starting,
-      SessionState.live
+      SessionState.live,
+      SessionState.expiring,
     ];
     if (validStates.contains(circle.state)) {
       return ThemedRaisedButton(

--- a/lib/app/circle/circle_session_info_page.dart
+++ b/lib/app/circle/circle_session_info_page.dart
@@ -234,7 +234,9 @@ class CircleSessionInfoPageState extends ConsumerState<CircleSessionInfoPage> {
           shrinkWrap: true,
           itemBuilder: (context, index) {
             SessionParticipant participant = participants[index];
-            if (_sessionState == SessionState.live && index == 0) {
+            if ((_sessionState == SessionState.live ||
+                    _sessionState == SessionState.expiring) &&
+                index == 0) {
               // for a live session, the first user in the list is the current
               // totem user. Don't allow them to be reordered for this case
               return CircleSessionParticipantListItem(

--- a/lib/app/circle/components/circle_session_controls.dart
+++ b/lib/app/circle/components/circle_session_controls.dart
@@ -51,14 +51,13 @@ class CircleSessionControlsState extends ConsumerState<CircleSessionControls> {
         children: [
           BottomTrayContainer(
             padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 16),
-            backgroundColor:
-                activeSession.state == SessionState.live ? Colors.black : null,
+            backgroundColor: activeSession.live ? Colors.black : null,
             child: Padding(
               padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 0),
               child: activeSession.state == SessionState.waiting
                   ? waitingControls(
                       context, ref, activeSession, role, authUser.uid)
-                  : activeSession.state == SessionState.live
+                  : activeSession.live
                       ? liveControls(context, ref, activeSession, role,
                           isPhoneLayout, constraints.maxWidth)
                       : emptyControls(context),
@@ -70,7 +69,7 @@ class CircleSessionControlsState extends ConsumerState<CircleSessionControls> {
             right: 0,
             child: Container(
               height: 1,
-              color: activeSession.state == SessionState.live
+              color: activeSession.live
                   ? Colors.black
                   : Theme.of(context).themeColors.trayBackground,
             ),

--- a/lib/app/circle/components/circle_snap_session_content.dart
+++ b/lib/app/circle/components/circle_snap_session_content.dart
@@ -63,7 +63,7 @@ class _CircleSnapSessionContentState
           },
           child: AnimatedSwitcher(
             duration: const Duration(milliseconds: 300),
-            child: (sessionProvider.state == SessionState.live)
+            child: (sessionProvider.live)
                 ? const CircleLiveVideoSession()
                 : Stack(
                     children: [

--- a/lib/models/active_session.dart
+++ b/lib/models/active_session.dart
@@ -60,6 +60,10 @@ class ActiveSession extends ChangeNotifier {
     return null;
   }
 
+  bool get live {
+    return [SessionState.live, SessionState.expiring].contains(_state);
+  }
+
   bool get ended {
     return [
       SessionState.complete,
@@ -237,7 +241,7 @@ class ActiveSession extends ChangeNotifier {
       }
     }
     _speakingOrder = List<String>.from(data["speakingOrder"] ?? []);
-    if (totemUser != null && state == SessionState.live) {
+    if (totemUser != null && live) {
       // ensure the totemUser is still valid... if not patch
       if (!_speakingOrder.contains(totemUser) && _speakingOrder.isNotEmpty) {
         //need to set a new totemUser

--- a/lib/services/agora/agora_communication_provider.dart
+++ b/lib/services/agora/agora_communication_provider.dart
@@ -704,7 +704,7 @@ class AgoraCommunicationProvider extends CommunicationProvider {
       return;
     }
     sessionProvider.activeSession?.userJoined(sessionUserId: user.toString());
-    if (sessionProvider.activeSession?.state == SessionState.live) {
+    if (sessionProvider.activeSession?.live ?? false) {
       _updateVideoStreamState();
     } else {
       _engine!.setRemoteVideoStreamType(user, VideoStreamType.Low);
@@ -782,10 +782,9 @@ class AgoraCommunicationProvider extends CommunicationProvider {
           session.state == SessionState.cancelling) {
         // mute users for the transitional states
         muteAudio(true);
-      } else if (session.state == SessionState.live && !session.userStatus) {
+      } else if (session.live && !session.userStatus) {
         // have to manage mute state based on changes to the state
-        bool started = (_lastState == SessionState.starting &&
-            session.state == SessionState.live);
+        bool started = (_lastState == SessionState.starting && session.live);
         if (started ||
             session.lastChange == ActiveSessionChange.totemChange ||
             session.lastChange == ActiveSessionChange.totemReceive) {

--- a/lib/services/firebase_providers/firebase_session_provider.dart
+++ b/lib/services/firebase_providers/firebase_session_provider.dart
@@ -184,8 +184,7 @@ class FirebaseSessionProvider extends SessionProvider {
       if (!validStates.contains(_activeSession!.state)) {
         return;
       }
-      bool complete = _activeSession!.state == SessionState.live ||
-          _activeSession!.state == SessionState.expiring;
+      bool complete = _activeSession!.live;
       try {
         await updateActiveSessionState(
             complete ? SessionState.ending : SessionState.cancelling);

--- a/server/functions/src/scheduler.ts
+++ b/server/functions/src/scheduler.ts
@@ -46,7 +46,7 @@ async function endExpiredSessions(): Promise<void> {
   // Added a grace period from when the session is set to expiring to when it is actually ended
   // by the server. This gives the frontend a chance to end gracefully rather then end abruptly
   // at the exact time the session is set to expire
-  const gracePeriod: number = 1800; // 30 minutes in seconds,
+  const gracePeriod = 1800; // 30 minutes in seconds,
   const now: Timestamp = new Timestamp(Timestamp.now().seconds - gracePeriod, 0);
   const ref = admin
     .firestore()

--- a/server/functions/src/scheduler.ts
+++ b/server/functions/src/scheduler.ts
@@ -43,7 +43,11 @@ async function performExpirationTasks(): Promise<void> {
  * @return {Promise}
  */
 async function endExpiredSessions(): Promise<void> {
-  const now: Timestamp = Timestamp.now();
+  // Added a grace period from when the session is set to expiring to when it is actually ended
+  // by the server. This gives the frontend a chance to end gracefully rather then end abruptly
+  // at the exact time the session is set to expire
+  const gracePeriod: number = 1800; // 30 minutes in seconds,
+  const now: Timestamp = new Timestamp(Timestamp.now().seconds - gracePeriod, 0);
   const ref = admin
     .firestore()
     .collection("snapCircles")

--- a/server/functions/src/session.ts
+++ b/server/functions/src/session.ts
@@ -103,6 +103,12 @@ export async function endSessionFor(
     }
   }
 
+  // if the session state was 'expired', then we don't want to update the state for the main circle
+  // entry to that but instead 'complete'.
+  if (endState === SessionState.expired) {
+    endState = SessionState.complete;
+  }
+
   // update the circle to completed state
   batch.update(circleRef, {
     state: nextSession ? SessionState.scheduled : endState,


### PR DESCRIPTION
Fixes #388 
Added a 30 min grace period to the end period for a circle session. This will let it run over by 30 min before its forced to end. Fixed handling of the 'expiring' state to treat it as live state, before this fix it wasn't handled and shows a waiting room view.
