### PR TITLE
Support for deleting a pending circle

### DIFF
--- a/lib/app/home/components/snap_circle_item.dart
+++ b/lib/app/home/components/snap_circle_item.dart
@@ -1,11 +1,15 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:introduction_screen/introduction_screen.dart';
 import 'package:lucide_icons/lucide_icons.dart';
 import 'package:totem/components/widgets/index.dart';
 import 'package:totem/models/index.dart';
+import 'package:totem/services/error_report.dart';
+import 'package:totem/services/index.dart';
 import 'package:totem/theme/index.dart';
 
-class SnapCircleItem extends StatelessWidget {
+class SnapCircleItem extends ConsumerWidget {
   static const double maxFullInfoWidth = 250;
   const SnapCircleItem({
     Key? key,
@@ -16,11 +20,17 @@ class SnapCircleItem extends StatelessWidget {
   final Function onPressed;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final t = AppLocalizations.of(context)!;
     final themeData = Theme.of(context);
     final themeColor = Theme.of(context).themeColors;
     final textStyles = themeData.textTheme;
+    AuthUser? user = ref.read(authServiceProvider).currentUser();
+    bool canCancel = user != null &&
+        circle.isPending &&
+        (user.hasRole(Role.admin) ||
+            circle.participantRole(user.uid) == Role.keeper);
+
     return Padding(
       padding: EdgeInsets.symmetric(
           vertical: 8.0, horizontal: themeData.pageHorizontalPadding),
@@ -29,78 +39,95 @@ class SnapCircleItem extends StatelessWidget {
         onTap: () {
           onPressed(circle);
         },
-        child: ListItemContainer(
-          child: Row(
-            crossAxisAlignment: CrossAxisAlignment.center,
-            children: [
-              Expanded(
-                child: Column(
-                  children: [
-                    Row(
-                      crossAxisAlignment: circle.description != null &&
-                              circle.description!.isNotEmpty
-                          ? CrossAxisAlignment.start
-                          : CrossAxisAlignment.center,
-                      children: [
-                        Padding(
-                          padding: const EdgeInsets.only(right: 10.0),
-                          child: CircleImage(
-                            circle: circle,
+        child: Stack(children: [
+          ListItemContainer(
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                Expanded(
+                  child: Column(
+                    children: [
+                      Row(
+                        crossAxisAlignment: circle.description != null &&
+                                circle.description!.isNotEmpty
+                            ? CrossAxisAlignment.start
+                            : CrossAxisAlignment.center,
+                        children: [
+                          Padding(
+                            padding: const EdgeInsets.only(right: 10.0),
+                            child: CircleImage(
+                              circle: circle,
+                            ),
                           ),
-                        ),
-                        const SizedBox(
-                          width: 4,
-                        ),
-                        Expanded(
-                          child: Column(
-                            crossAxisAlignment: CrossAxisAlignment.start,
-                            children: [
-                              const SizedBox(height: 2),
-                              Text(
-                                circle.name,
-                                style: textStyles.headline3,
-                                maxLines: 2,
-                                overflow: TextOverflow.ellipsis,
-                              ),
-                              const SizedBox(height: 8),
-                              if (circle.description != null &&
-                                  circle.description!.isNotEmpty) ...[
+                          const SizedBox(
+                            width: 4,
+                          ),
+                          Expanded(
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                const SizedBox(height: 2),
                                 Text(
-                                  circle.description!,
+                                  circle.name,
+                                  style: textStyles.headline3,
                                   maxLines: 2,
                                   overflow: TextOverflow.ellipsis,
                                 ),
-                                const SizedBox(
-                                  height: 8,
-                                ),
+                                const SizedBox(height: 8),
+                                if (circle.description != null &&
+                                    circle.description!.isNotEmpty) ...[
+                                  Text(
+                                    circle.description!,
+                                    maxLines: 2,
+                                    overflow: TextOverflow.ellipsis,
+                                  ),
+                                  const SizedBox(
+                                    height: 8,
+                                  ),
+                                ],
+                                if (circle.createdBy != null) ...[
+                                  Text(
+                                    t.createdBy(circle.createdBy!.name),
+                                    style: TextStyle(
+                                        color: themeColor.primaryText,
+                                        fontSize: 13,
+                                        fontWeight: FontWeight.w500),
+                                  ),
+                                ],
                               ],
-                              if (circle.createdBy != null) ...[
-                                Text(
-                                  t.createdBy(circle.createdBy!.name),
-                                  style: TextStyle(
-                                      color: themeColor.primaryText,
-                                      fontSize: 13,
-                                      fontWeight: FontWeight.w500),
-                                ),
-                              ],
-                            ],
+                            ),
                           ),
-                        ),
-                      ],
-                    ),
-                    const SizedBox(height: 8),
-                    _sessionInfo(context),
-                  ],
+                        ],
+                      ),
+                      const SizedBox(height: 8),
+                      _sessionInfo(context),
+                    ],
+                  ),
                 ),
-              ),
-              const SizedBox(
-                width: 8,
-              ),
-              Icon(LucideIcons.arrowRight,
-                  size: 24, color: themeData.themeColors.iconNext),
-            ],
+                const SizedBox(
+                  width: 8,
+                ),
+                Icon(LucideIcons.arrowRight,
+                    size: 24, color: themeData.themeColors.iconNext),
+              ],
+            ),
           ),
-        ),
+          if (canCancel)
+            Positioned(
+              top: 5,
+              right: 5,
+              child: IconButton(
+                icon: Icon(
+                  LucideIcons.trash,
+                  size: 12,
+                  color: themeData.themeColors.error,
+                ),
+                onPressed: () {
+                  _promptCancel(context, ref);
+                },
+              ),
+            ),
+        ]),
       ),
     );
   }
@@ -151,5 +178,51 @@ class SnapCircleItem extends StatelessWidget {
         ],
       );
     });
+  }
+
+  void _promptCancel(BuildContext context, WidgetRef ref) async {
+    final t = AppLocalizations.of(context)!;
+    // set up the AlertDialog
+    final actions = [
+      TextButton(
+        child: Text(t.endSession),
+        onPressed: () {
+          Navigator.of(context).pop("leave");
+        },
+      ),
+      TextButton(
+        child: Text(t.cancel),
+        onPressed: () {
+          Navigator.of(context).pop("cancel");
+        },
+      ),
+    ];
+
+    AlertDialog alert = AlertDialog(
+      title: Text(t.endSessionPrompt),
+      content: Text(t.endSessionPromptMessage),
+      actions: actions,
+    );
+    // show the dialog
+    final result = await showDialog(
+      context: context,
+      barrierDismissible: false,
+      builder: (BuildContext context) {
+        return alert;
+      },
+    );
+    if (result != "cancel") {
+      return _cancelCircle(ref);
+    }
+  }
+
+  void _cancelCircle(WidgetRef ref) async {
+    var repo = ref.read(repositoryProvider);
+    try {
+      await repo.cancelPendingSession(circle: circle);
+    } on ServiceException catch (ex, stack) {
+      debugPrint('Error creating circle: $ex');
+      await reportError(ex, stack);
+    }
   }
 }

--- a/lib/app/home/components/snap_circle_item.dart
+++ b/lib/app/home/components/snap_circle_item.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:introduction_screen/introduction_screen.dart';
 import 'package:lucide_icons/lucide_icons.dart';
 import 'package:totem/components/widgets/index.dart';
 import 'package:totem/models/index.dart';

--- a/lib/models/circle.dart
+++ b/lib/models/circle.dart
@@ -77,6 +77,14 @@ class Circle extends CircleTemplate {
     return completeStates.contains(state);
   }
 
+  bool get isPending {
+    const pendingStates = [
+      SessionState.waiting,
+      SessionState.scheduled,
+    ];
+    return pendingStates.contains(state);
+  }
+
   Session get session {
     return Session.fromJson({}, circle: this, id: id);
   }

--- a/lib/services/session_provider.dart
+++ b/lib/services/session_provider.dart
@@ -16,6 +16,7 @@ abstract class SessionProvider extends ChangeNotifier {
       {required Circle circle, required String uid});
   Future<void> startActiveSession();
   Future<void> endActiveSession();
+  Future<void> cancelPendingSession({required Session session});
   void clear();
   ActiveSession? get activeSession;
   Future<SessionToken> requestSessionToken({required Session session});

--- a/lib/services/totem_repository.dart
+++ b/lib/services/totem_repository.dart
@@ -132,6 +132,8 @@ class TotemRepository {
   ActiveSession? get activeSession => _sessionProvider.activeSession;
   Future<void> updateActiveSession(Map<String, dynamic> sessionData) =>
       _sessionProvider.updateActiveSession(sessionData);
+  Future<void> cancelPendingSession({required Circle circle}) =>
+      _sessionProvider.cancelPendingSession(session: circle.session);
 
   // Analytics
   AnalyticsProvider get analyticsProvider {

--- a/server/firestore.rules
+++ b/server/firestore.rules
@@ -32,7 +32,8 @@ service cloud.firestore {
       allow create: if false; // Only created by cloud function
       match /{documents=**} {
         allow read: if request.auth != null;
-        allow write: if isDocOwner(resource.data.keeper); // Only circle keeper can update
+        // Only circle keeper or admincan update
+        allow write: if isDocOwner(resource.data.keeper) || hasAnyRole(["admin"]); 
       }
     }
     match /activeCircles/{circleId}/{documents=**} {


### PR DESCRIPTION
issue #335
Frontend:
- Add getter for pending (waiting/scheduled) circle
- Add support for cancelling a waiting circle by calling `endSnapSession` (we will handle scheduled sessions later after we add support for displaying them).
- Add icon button to a circle card if it can be cancelled by the user (circle is `pending` and user is the circle keeper or is an admin) Backend:
- Update rules to allow admins to edit circle data
- Update `endSessionFor` so it records cancelled circles in the session history and so circles always end in either "completed" or "scheduled" state.